### PR TITLE
Support for 7TV Cosmetics (colored/animated name plates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !.github/FUNDING.yml
 !assets/**
 !ios/Runner/Assets.xcassets/LaunchImage.imageset/**
+!ios/Runner.xcodeproj/xcshareddata/xcschemes/**
 
 # Global avoids
 .DS_Store

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/lib/Components/ChatMessage.dart
+++ b/lib/Components/ChatMessage.dart
@@ -9,7 +9,7 @@ import '/Badges/FFZAPBadges.dart';
 import '/Badges/FFZBadges.dart';
 import '/Badges/SevenTVBadges.dart';
 import '/Components/WidgetTooltip.dart';
-import '/Cosmetics/SevenTvCosmeticsCubit.dart';
+import '../Cosmetics/SevenTvCosmetics.dart';
 import '/Settings/Settings.dart';
 import '/Settings/SettingsState.dart';
 import 'package:flutter/gestures.dart';
@@ -48,17 +48,21 @@ class ChatMessage extends StatelessWidget {
   Color getUserColor(BuildContext context, Color color) {
     switch (Theme.of(context).brightness) {
       case Brightness.dark:
-        final hsl = HSLColor.fromColor(Color(color.value == 0xFF000000 ? 0xFF010101 : color.value));
+        final hsl = HSLColor.fromColor(
+            Color(color.value == 0xFF000000 ? 0xFF010101 : color.value));
         return hsl.withLightness(hsl.lightness.clamp(0.6, 1.0)).toColor();
       case Brightness.light:
-        final hsl = HSLColor.fromColor(Color(color.value == 0xFF000000 ? 0xFF010101 : color.value));
+        final hsl = HSLColor.fromColor(
+            Color(color.value == 0xFF000000 ? 0xFF010101 : color.value));
         return hsl.withLightness(hsl.lightness.clamp(0.0, 0.4)).toColor();
     }
   }
 
   Future<ui.Image> imageFromUrl(String url) {
     var completer = Completer<ui.Image>();
-    NetworkImage(url).resolve(ImageConfiguration()).addListener(ImageStreamListener((image, synchronousCall) {
+    NetworkImage(url)
+        .resolve(ImageConfiguration())
+        .addListener(ImageStreamListener((image, synchronousCall) {
       completer.complete(image.image);
     }));
     return completer.future;
@@ -66,16 +70,27 @@ class ChatMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var color = getUserColor(context, Color(int.tryParse(message.user?.color ?? '777777', radix: 16) ?? 0x777777).withAlpha(255));
+    var color = getUserColor(
+        context,
+        Color(int.tryParse(message.user?.color ?? '777777', radix: 16) ??
+                0x777777)
+            .withAlpha(255));
     var spans = <InlineSpan>[];
     var shadowSpread = 1.0;
     var shadowColor = Theme.of(context).colorScheme.background;
     var shadows = shadow
         ? [
-            Shadow(offset: Offset(-shadowSpread, -shadowSpread), color: shadowColor),
-            Shadow(offset: Offset(shadowSpread, -shadowSpread), color: shadowColor),
-            Shadow(offset: Offset(shadowSpread, shadowSpread), color: shadowColor),
-            Shadow(offset: Offset(-shadowSpread, shadowSpread), color: shadowColor),
+            Shadow(
+                offset: Offset(-shadowSpread, -shadowSpread),
+                color: shadowColor),
+            Shadow(
+                offset: Offset(shadowSpread, -shadowSpread),
+                color: shadowColor),
+            Shadow(
+                offset: Offset(shadowSpread, shadowSpread), color: shadowColor),
+            Shadow(
+                offset: Offset(-shadowSpread, shadowSpread),
+                color: shadowColor),
           ]
         : null;
 
@@ -114,7 +129,8 @@ class ChatMessage extends StatelessWidget {
           );
           break;
         case twitch.MessageTokenType.Image:
-          if (!(BlocProvider.of<Settings>(context).state as SettingsLoaded).messageImagePreview) {
+          if (!(BlocProvider.of<Settings>(context).state as SettingsLoaded)
+              .messageImagePreview) {
             spans.add(
               TextSpan(
                 children: [
@@ -125,7 +141,9 @@ class ChatMessage extends StatelessWidget {
                       decoration: TextDecoration.underline,
                       shadows: shadows,
                     ),
-                    recognizer: TapGestureRecognizer()..onTap = () async => launch(Uri.parse(token.data).toString()),
+                    recognizer: TapGestureRecognizer()
+                      ..onTap =
+                          () async => launch(Uri.parse(token.data).toString()),
                   ),
                   TextSpan(text: ' '),
                 ],
@@ -142,8 +160,10 @@ class ChatMessage extends StatelessWidget {
                   child: Padding(
                     padding: const EdgeInsets.all(2.0),
                     child: InkWell(
-                      onTap: () async => launch(Uri.parse(token.data).toString()), //'https://cdn.imgproxify.com/image?url=${Uri.encodeComponent(token.data)}'),
-                      child: NetworkImageW(Uri.parse(token.data).toString()), //'https://cdn.imgproxify.com/image?url=${Uri.encodeComponent(token.data)}'),
+                      onTap: () async => launch(Uri.parse(token.data)
+                          .toString()), //'https://cdn.imgproxify.com/image?url=${Uri.encodeComponent(token.data)}'),
+                      child: NetworkImageW(Uri.parse(token.data)
+                          .toString()), //'https://cdn.imgproxify.com/image?url=${Uri.encodeComponent(token.data)}'),
                     ),
                   ),
                 ),
@@ -182,8 +202,12 @@ class ChatMessage extends StatelessWidget {
                       child: Padding(
                         padding: const EdgeInsets.only(right: 4.0),
                         child: NetworkImageW(
-                          token.data.provider == 'Twitch' ? token.data.mipmap[1] : token.data.mipmap.last,
-                          scale: token.data.provider == 'Twitch' ? 2.0 : (token.data.mipmap.length == 1 ? 1.0 : 4.0),
+                          token.data.provider == 'Twitch'
+                              ? token.data.mipmap[1]
+                              : token.data.mipmap.last,
+                          scale: token.data.provider == 'Twitch'
+                              ? 2.0
+                              : (token.data.mipmap.length == 1 ? 1.0 : 4.0),
                           height: token.data.provider == 'Emoji' ? 24.0 : null,
                         ),
                       ),
@@ -197,7 +221,8 @@ class ChatMessage extends StatelessWidget {
               TextSpan(
                 text: '${(token.data as twitch.Emote).name!} ',
                 style: TextStyle(
-                  color: (message.user == null || message.action) ? color : null,
+                  color:
+                      (message.user == null || message.action) ? color : null,
                   shadows: shadows,
                 ),
               ),
@@ -262,7 +287,9 @@ class ChatMessage extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(right: 4.0),
                         child: NetworkImageW(
-                          emote.provider == 'Twitch' ? emote.mipmap[1] : emote.mipmap.last,
+                          emote.provider == 'Twitch'
+                              ? emote.mipmap[1]
+                              : emote.mipmap.last,
                           scale: emote.provider == 'Twitch' ? 2.0 : 4.0,
                           height: emote.provider == 'Emoji' ? 24.0 : null,
                         ),
@@ -326,7 +353,9 @@ class ChatMessage extends StatelessWidget {
       key: ValueKey(message.id),
       child: Container(
         width: double.infinity,
-        color: message.mention ? Theme.of(context).colorScheme.primary.withAlpha(48) : backgroundColor,
+        color: message.mention
+            ? Theme.of(context).colorScheme.primary.withAlpha(48)
+            : backgroundColor,
         child: InkWell(
           onDoubleTap: () async {
             await Clipboard.setData(ClipboardData(text: message.body));
@@ -372,9 +401,12 @@ class ChatMessage extends StatelessWidget {
                             shadows: shadows,
                           ),
                         ),
-                      if ((BlocProvider.of<Settings>(context).state as SettingsLoaded).messageTimestamp)
+                      if ((BlocProvider.of<Settings>(context).state
+                              as SettingsLoaded)
+                          .messageTimestamp)
                         TextSpan(
-                          text: '${message.dateTime!.hour.toString().padLeft(2, '0')}:${message.dateTime!.minute.toString().padLeft(2, '0')} ',
+                          text:
+                              '${message.dateTime!.hour.toString().padLeft(2, '0')}:${message.dateTime!.minute.toString().padLeft(2, '0')} ',
                           style: TextStyle(
                             // fontWeight: FontWeight.bold,
                             shadows: shadows,
@@ -396,16 +428,27 @@ class ChatMessage extends StatelessWidget {
                         // Good god chatsen2 will need something better than this
                         for (var badge in [
                           ...message.badges,
-                          ...BlocProvider.of<BTTVBadges>(context).getBadgesForUser('${message.user?.id}'),
-                          ...BlocProvider.of<FFZBadges>(context).getBadgesForUser('${message.user?.login?.toLowerCase()}'),
-                          ...BlocProvider.of<FFZAPBadges>(context).getBadgesForUser('${message.user?.id}'),
-                          ...BlocProvider.of<ChatterinoBadges>(context).getBadgesForUser('${message.user?.id}'),
-                          ...BlocProvider.of<DankChatBadges>(context).getBadgesForUser('${message.user?.id}'),
-                          ...BlocProvider.of<ChattyBadges>(context).getBadgesForUser('${message.user?.login}'),
-                          ...BlocProvider.of<SevenTVBadges>(context).getBadgesForUser('${message.user?.id}'),
-                          ...BlocProvider.of<SevenTvCosmeticsCubit>(context).getBadgesForTwitchUserId(message.user?.id),
-                          ...BlocProvider.of<ChatsenBadges>(context).getBadgesForUser('${message.user?.id}'),
-                          ...BlocProvider.of<Chatsen2Badges>(context).getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<BTTVBadges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<FFZBadges>(context)
+                              .getBadgesForUser(
+                                  '${message.user?.login?.toLowerCase()}'),
+                          ...BlocProvider.of<FFZAPBadges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<ChatterinoBadges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<DankChatBadges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<ChattyBadges>(context)
+                              .getBadgesForUser('${message.user?.login}'),
+                          ...BlocProvider.of<SevenTVBadges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<SevenTvCosmetics>(context)
+                              .getBadgesForTwitchUserId(message.user?.id),
+                          ...BlocProvider.of<ChatsenBadges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
+                          ...BlocProvider.of<Chatsen2Badges>(context)
+                              .getBadgesForUser('${message.user?.id}'),
                         ])
                           WidgetSpan(
                             child: WidgetTooltip(
@@ -415,12 +458,23 @@ class ChatMessage extends StatelessWidget {
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
                                     Padding(
-                                      padding: const EdgeInsets.only(bottom: 4.0),
+                                      padding:
+                                          const EdgeInsets.only(bottom: 4.0),
                                       child: ClipRRect(
-                                        borderRadius: badge.color != null ? BorderRadius.circular(96.0 / 8.0) : BorderRadius.zero,
+                                        borderRadius: badge.color != null
+                                            ? BorderRadius.circular(96.0 / 8.0)
+                                            : BorderRadius.zero,
                                         child: Container(
-                                          color: badge.color != null ? Color(int.tryParse(badge.color ?? '777777', radix: 16) ?? 0x777777).withAlpha(255) : null,
-                                          child: badge.mipmap!.last!.endsWith('.svg')
+                                          color: badge.color != null
+                                              ? Color(int.tryParse(
+                                                          badge.color ??
+                                                              '777777',
+                                                          radix: 16) ??
+                                                      0x777777)
+                                                  .withAlpha(255)
+                                              : null,
+                                          child: badge.mipmap!.last!
+                                                  .endsWith('.svg')
                                               ? SvgPicture.network(
                                                   badge.mipmap!.last!,
                                                   height: 96.0,
@@ -436,16 +490,26 @@ class ChatMessage extends StatelessWidget {
                                       ),
                                     ),
                                     Text('${badge.title}'),
-                                    if (badge.title != badge.description && badge.description != null) Text('${badge.description}'),
+                                    if (badge.title != badge.description &&
+                                        badge.description != null)
+                                      Text('${badge.description}'),
                                   ],
                                 ),
                               ),
                               child: Padding(
                                 padding: const EdgeInsets.only(right: 4.0),
                                 child: ClipRRect(
-                                  borderRadius: badge.color != null ? BorderRadius.circular(2.0) : BorderRadius.zero,
+                                  borderRadius: badge.color != null
+                                      ? BorderRadius.circular(2.0)
+                                      : BorderRadius.zero,
                                   child: Container(
-                                    color: badge.color != null ? Color(int.tryParse(badge.color ?? '777777', radix: 16) ?? 0x777777).withAlpha(255) : null,
+                                    color: badge.color != null
+                                        ? Color(int.tryParse(
+                                                    badge.color ?? '777777',
+                                                    radix: 16) ??
+                                                0x777777)
+                                            .withAlpha(255)
+                                        : null,
                                     child: badge.mipmap!.last!.endsWith('.svg')
                                         ? SvgPicture.network(
                                             badge.mipmap!.last!,
@@ -465,7 +529,10 @@ class ChatMessage extends StatelessWidget {
                       if (message.user != null)
                         () {
                           final usernameText = '${message.user!.displayName}' +
-                              (message.user!.displayName!.toLowerCase() != message.user!.login!.toLowerCase() ? ' (${message.user!.login})' : '') +
+                              (message.user!.displayName!.toLowerCase() !=
+                                      message.user!.login!.toLowerCase()
+                                  ? ' (${message.user!.login})'
+                                  : '') +
                               (message.action ? ' ' : ': ');
                           final usernameStyle = TextStyle(
                             color: color,
@@ -473,17 +540,23 @@ class ChatMessage extends StatelessWidget {
                             shadows: shadows,
                           );
 
-                          final paint = BlocProvider.of<SevenTvCosmeticsCubit>(context).getPaintForTwitchUserId(message.user?.id);
+                          final paint =
+                              BlocProvider.of<SevenTvCosmetics>(context)
+                                  .getPaintForTwitchUserId(message.user?.id);
                           if (paint == null) {
                             return TextSpan(
                               text: usernameText,
                               style: usernameStyle,
                               recognizer: TapGestureRecognizer()
-                                ..onTap = () async => Navigator.of(context).push(
-                                      MaterialPageRoute(
-                                        builder: (BuildContext context) => SearchPage(channel: message.channel, user: message.user),
-                                      ),
-                                    ),
+                                ..onTap =
+                                    () async => Navigator.of(context).push(
+                                          MaterialPageRoute(
+                                            builder: (BuildContext context) =>
+                                                SearchPage(
+                                                    channel: message.channel,
+                                                    user: message.user),
+                                          ),
+                                        ),
                             );
                           }
 
@@ -494,7 +567,9 @@ class ChatMessage extends StatelessWidget {
                               behavior: HitTestBehavior.opaque,
                               onTap: () async => Navigator.of(context).push(
                                 MaterialPageRoute(
-                                  builder: (BuildContext context) => SearchPage(channel: message.channel, user: message.user),
+                                  builder: (BuildContext context) => SearchPage(
+                                      channel: message.channel,
+                                      user: message.user),
                                 ),
                               ),
                               child: SevenTvPaintedText(

--- a/lib/Components/SevenTvPaintedText.dart
+++ b/lib/Components/SevenTvPaintedText.dart
@@ -1,0 +1,319 @@
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../Cosmetics/SevenTvCosmeticsCubit.dart';
+
+class SevenTvPaintedText extends StatefulWidget {
+  final String text;
+  final TextStyle style;
+  final SevenTvPaint paint;
+
+  const SevenTvPaintedText({
+    Key? key,
+    required this.text,
+    required this.style,
+    required this.paint,
+  }) : super(key: key);
+
+  @override
+  State<SevenTvPaintedText> createState() => _SevenTvPaintedTextState();
+}
+
+class _SevenTvPaintedTextState extends State<SevenTvPaintedText> {
+  ImageStream? _stream;
+  ImageStreamListener? _listener;
+  ui.Image? _image;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveImageIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(covariant SevenTvPaintedText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.paint.imageUrl != widget.paint.imageUrl ||
+        oldWidget.paint.function != widget.paint.function) {
+      _stopListening();
+      _image = null;
+      _resolveImageIfNeeded();
+    }
+  }
+
+  @override
+  void dispose() {
+    _stopListening();
+    super.dispose();
+  }
+
+  void _stopListening() {
+    if (_stream != null && _listener != null) {
+      _stream!.removeListener(_listener!);
+    }
+    _stream = null;
+    _listener = null;
+  }
+
+  void _resolveImageIfNeeded() {
+    if (widget.paint.function != 'URL') return;
+    final url = widget.paint.imageUrl;
+    if (url == null || url.isEmpty) return;
+
+    final provider = CachedNetworkImageProvider(url);
+    final stream = provider.resolve(const ImageConfiguration());
+    _stream = stream;
+    _listener = ImageStreamListener((info, _) {
+      if (!mounted) return;
+      setState(() {
+        _image = info.image;
+      });
+    });
+    stream.addListener(_listener!);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final paint = widget.paint;
+
+    Widget textWidget = _buildPaintedText(paint);
+
+    if (paint.dropShadows.isNotEmpty) {
+      textWidget = _applyDropShadows(textWidget, paint.dropShadows);
+    }
+
+    return textWidget;
+  }
+
+  Widget _buildPaintedText(SevenTvPaint paint) {
+    if (paint.function == 'URL') {
+      if (_image == null) {
+        return Text(widget.text, style: widget.style);
+      }
+
+      return ShaderMask(
+        blendMode: BlendMode.srcIn,
+        shaderCallback: (bounds) => _imageShaderCover(_image!, bounds),
+        child: Text(
+          widget.text,
+          style: widget.style.copyWith(color: Colors.white),
+        ),
+      );
+    }
+
+    if (paint.function == 'GRADIENT' || paint.function == 'LINEAR_GRADIENT') {
+      if (paint.stops.isEmpty) return Text(widget.text, style: widget.style);
+      return ShaderMask(
+        blendMode: BlendMode.srcIn,
+        shaderCallback: (bounds) => _createLinearGradientShader(bounds, paint),
+        child: Text(
+          widget.text,
+          style: widget.style.copyWith(color: Colors.white),
+        ),
+      );
+    }
+
+    if (paint.function == 'RADIAL_GRADIENT') {
+      if (paint.stops.isEmpty) return Text(widget.text, style: widget.style);
+      return ShaderMask(
+        blendMode: BlendMode.srcIn,
+        shaderCallback: (bounds) => _createRadialGradientShader(bounds, paint),
+        child: Text(
+          widget.text,
+          style: widget.style.copyWith(color: Colors.white),
+        ),
+      );
+    }
+
+    return Text(widget.text, style: widget.style);
+  }
+
+  Widget _applyDropShadows(Widget child, List<SevenTvDropShadow> shadows) {
+    return Stack(
+      children: [
+        for (final shadow in shadows.where((s) => s.radius > 0))
+          Transform.translate(
+            offset: Offset(shadow.xOffset, shadow.yOffset),
+            child: Text(
+              widget.text,
+              style: widget.style.copyWith(
+                foreground: Paint()
+                  ..style = PaintingStyle.fill
+                  ..color = shadow.color
+                  ..maskFilter = MaskFilter.blur(
+                    BlurStyle.normal,
+                    shadow.radius / 2,
+                  ),
+              ),
+            ),
+          ),
+        child,
+      ],
+    );
+  }
+
+  ui.Shader _imageShaderCover(ui.Image image, Rect bounds) {
+    final iw = image.width.toDouble();
+    final ih = image.height.toDouble();
+    final bw = bounds.width;
+    final bh = bounds.height;
+
+    final scale = max(bw / iw, bh / ih);
+    final tx = (bw - iw * scale) / 2.0;
+    final ty = (bh - ih * scale) / 2.0;
+
+    final matrix = Float64List(16);
+    matrix[0] = scale;
+    matrix[5] = scale;
+    matrix[10] = 1.0;
+    matrix[15] = 1.0;
+    matrix[12] = tx;
+    matrix[13] = ty;
+
+    return ui.ImageShader(
+      image,
+      widget.paint.repeat ? ui.TileMode.repeated : ui.TileMode.clamp,
+      widget.paint.repeat ? ui.TileMode.repeated : ui.TileMode.clamp,
+      matrix,
+    );
+  }
+
+  ui.Shader _createLinearGradientShader(Rect rect, SevenTvPaint paint) {
+    final angle = paint.angle ?? 90.0;
+    final stops = paint.stops;
+    final repeat = paint.repeat;
+
+    final angleStep = (angle ~/ 90) % 4;
+
+    Offset startPoint;
+    Offset endPoint;
+
+    switch (angleStep) {
+      case 0:
+        startPoint = rect.bottomLeft;
+        endPoint = rect.topRight;
+        break;
+      case 1:
+        startPoint = rect.topLeft;
+        endPoint = rect.bottomRight;
+        break;
+      case 2:
+        startPoint = rect.topRight;
+        endPoint = rect.bottomLeft;
+        break;
+      case 3:
+        startPoint = rect.bottomRight;
+        endPoint = rect.topLeft;
+        break;
+      default:
+        startPoint = rect.bottomLeft;
+        endPoint = rect.topRight;
+    }
+
+    final center = rect.center;
+    final gradientAxisAngle = (90.0 - angle) * pi / 180.0;
+    final colorAxisAngle = -angle * pi / 180.0;
+
+    final gradientStart = _lineIntersection(
+      center,
+      gradientAxisAngle,
+      startPoint,
+      colorAxisAngle,
+    );
+    final gradientEnd = _lineIntersection(
+      center,
+      gradientAxisAngle,
+      endPoint,
+      colorAxisAngle,
+    );
+
+    if (gradientStart == null || gradientEnd == null) {
+      return ui.Gradient.linear(
+        rect.centerLeft,
+        rect.centerRight,
+        stops.map((s) => s.color).toList(),
+        stops.map((s) => s.position).toList(),
+      );
+    }
+
+    Offset finalStart = gradientStart;
+    Offset finalEnd = gradientEnd;
+
+    if (repeat && stops.isNotEmpty) {
+      finalStart =
+          _lerpOffset(gradientStart, gradientEnd, stops.first.position);
+      finalEnd = _lerpOffset(gradientStart, gradientEnd, stops.last.position);
+    }
+
+    final colors = stops.map((s) => s.color).toList();
+    final positions = repeat
+        ? stops.map((s) => _offsetRepeatingPosition(s.position, stops)).toList()
+        : stops.map((s) => s.position).toList();
+
+    return ui.Gradient.linear(
+      finalStart,
+      finalEnd,
+      colors,
+      positions,
+      repeat ? TileMode.repeated : TileMode.clamp,
+    );
+  }
+
+  ui.Shader _createRadialGradientShader(Rect rect, SevenTvPaint paint) {
+    final stops = paint.stops;
+    final repeat = paint.repeat;
+
+    final cx = rect.left + rect.width / 2;
+    final cy = rect.top + rect.height / 2;
+    final center = Offset(cx, cy);
+
+    var radius = max(rect.width, rect.height) / 2;
+    if (repeat && stops.isNotEmpty) {
+      radius = radius * stops.last.position;
+    }
+
+    final colors = stops.map((s) => s.color).toList();
+    final positions = repeat
+        ? stops.map((s) => _offsetRepeatingPosition(s.position, stops)).toList()
+        : stops.map((s) => s.position).toList();
+
+    return ui.Gradient.radial(
+      center,
+      radius,
+      colors,
+      positions,
+      repeat ? TileMode.repeated : TileMode.clamp,
+    );
+  }
+
+  Offset? _lineIntersection(Offset p1, double a1, Offset p2, double a2) {
+    final d1 = Offset(cos(a1), -sin(a1));
+    final d2 = Offset(cos(a2), -sin(a2));
+
+    final cross = d1.dx * d2.dy - d1.dy * d2.dx;
+    if (cross.abs() < 1e-10) return null;
+
+    final dx = p2.dx - p1.dx;
+    final dy = p2.dy - p1.dy;
+    final t = (dx * d2.dy - dy * d2.dx) / cross;
+
+    return Offset(p1.dx + t * d1.dx, p1.dy + t * d1.dy);
+  }
+
+  Offset _lerpOffset(Offset a, Offset b, double t) {
+    return Offset(a.dx + (b.dx - a.dx) * t, a.dy + (b.dy - a.dy) * t);
+  }
+
+  double _offsetRepeatingPosition(double pos, List<SevenTvPaintStop> stops) {
+    if (stops.isEmpty) return pos;
+    final first = stops.first.position;
+    final last = stops.last.position;
+    final range = last - first;
+    if (range.abs() < 1e-10) return 0.0;
+    return (pos - first) / range;
+  }
+}

--- a/lib/Cosmetics/SevenTvCosmetics.dart
+++ b/lib/Cosmetics/SevenTvCosmetics.dart
@@ -77,8 +77,8 @@ class SevenTvCosmeticsState {
       );
 }
 
-class SevenTvCosmeticsCubit extends Cubit<SevenTvCosmeticsState> {
-  SevenTvCosmeticsCubit() : super(SevenTvCosmeticsState.initial()) {}
+class SevenTvCosmetics extends Cubit<SevenTvCosmeticsState> {
+  SevenTvCosmetics() : super(SevenTvCosmeticsState.initial()) {}
 
   static const _wsUrl = 'wss://events.7tv.io/v3';
 

--- a/lib/Cosmetics/SevenTvCosmeticsCubit.dart
+++ b/lib/Cosmetics/SevenTvCosmeticsCubit.dart
@@ -1,0 +1,551 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter_chatsen_irc/Twitch.dart' as twitch;
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class SevenTvDropShadow {
+  final double xOffset;
+  final double yOffset;
+  final double radius;
+  final Color color;
+
+  const SevenTvDropShadow({
+    required this.xOffset,
+    required this.yOffset,
+    required this.radius,
+    required this.color,
+  });
+
+  SevenTvDropShadow scaled(double scale) {
+    return SevenTvDropShadow(
+      xOffset: xOffset * scale,
+      yOffset: yOffset * scale,
+      radius: radius * scale,
+      color: color,
+    );
+  }
+}
+
+class SevenTvPaintStop {
+  final Color color;
+  final double position;
+
+  const SevenTvPaintStop({
+    required this.color,
+    required this.position,
+  });
+}
+
+class SevenTvPaint {
+  final String function;
+  final bool repeat;
+  final double? angle;
+  final String? shape;
+  final String? imageUrl;
+  final List<SevenTvPaintStop> stops;
+  final List<SevenTvDropShadow> dropShadows;
+
+  const SevenTvPaint({
+    required this.function,
+    required this.repeat,
+    required this.stops,
+    this.angle,
+    this.shape,
+    this.imageUrl,
+    this.dropShadows = const [],
+  });
+}
+
+class SevenTvCosmeticsState {
+  final Map<int, List<twitch.Badge>> badgesByTwitchUserId;
+  final Map<int, SevenTvPaint> paintsByTwitchUserId;
+  final Set<int> subscribedChannelIds;
+
+  const SevenTvCosmeticsState({
+    required this.badgesByTwitchUserId,
+    required this.paintsByTwitchUserId,
+    required this.subscribedChannelIds,
+  });
+
+  factory SevenTvCosmeticsState.initial() => const SevenTvCosmeticsState(
+        badgesByTwitchUserId: {},
+        paintsByTwitchUserId: {},
+        subscribedChannelIds: <int>{},
+      );
+}
+
+class SevenTvCosmeticsCubit extends Cubit<SevenTvCosmeticsState> {
+  SevenTvCosmeticsCubit() : super(SevenTvCosmeticsState.initial()) {}
+
+  static const _wsUrl = 'wss://events.7tv.io/v3';
+
+  WebSocketChannel? _socket;
+  StreamSubscription? _socketSub;
+
+  int _lastHeartbeat = 0;
+  int _expectedHeartbeatInterval = 0;
+  int _heartbeatFailedCount = 0;
+  Timer? _heartbeatTimer;
+  bool _connectedOnce = false;
+
+  final Map<String, Map<String, dynamic>> _cosmeticsById = {};
+  final Map<String, List<Map<String, dynamic>>> _entitlementsByCosmeticId = {};
+  final Set<String> _emittedUserCosmeticKeys = {};
+
+  void subscribeToChannelId(int channelId) {
+    if (state.subscribedChannelIds.contains(channelId)) return;
+    emit(
+      SevenTvCosmeticsState(
+        badgesByTwitchUserId: state.badgesByTwitchUserId,
+        paintsByTwitchUserId: state.paintsByTwitchUserId,
+        subscribedChannelIds: {...state.subscribedChannelIds, channelId},
+      ),
+    );
+    _ensureConnected();
+    _subscribeChannel(channelId);
+  }
+
+  @override
+  Future<void> close() async {
+    _heartbeatTimer?.cancel();
+    await _socketSub?.cancel();
+    await _socket?.sink.close();
+    return super.close();
+  }
+
+  List<twitch.Badge> getBadgesForTwitchUserId(int? twitchUserId) {
+    if (twitchUserId == null) return const [];
+    return state.badgesByTwitchUserId[twitchUserId] ?? const [];
+  }
+
+  SevenTvPaint? getPaintForTwitchUserId(int? twitchUserId) {
+    if (twitchUserId == null) return null;
+    return state.paintsByTwitchUserId[twitchUserId];
+  }
+
+  void _ensureConnected() {
+    if (_socket != null) return;
+    _connectedOnce = true;
+
+    _socket = WebSocketChannel.connect(Uri.parse(_wsUrl));
+    _socketSub = _socket!.stream.listen(
+      (event) => _handleMessage(event),
+      onDone: _reconnect,
+      onError: (_) => _reconnect(),
+    );
+
+    for (final channelId in state.subscribedChannelIds) {
+      _subscribeChannel(channelId);
+    }
+  }
+
+  void _reconnect() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+
+    _socketSub?.cancel();
+    _socketSub = null;
+
+    _socket?.sink.close();
+    _socket = null;
+
+    if (!_connectedOnce) return;
+    Future.delayed(const Duration(seconds: 1), _ensureConnected);
+  }
+
+  void _send(int op, Map<String, dynamic> data) {
+    final socket = _socket;
+    if (socket == null) return;
+    final payload = {
+      'op': op,
+      't': DateTime.now().millisecondsSinceEpoch,
+      'd': data
+    };
+    final encoded = jsonEncode(payload);
+    socket.sink.add(encoded);
+  }
+
+  void _subscribeChannel(int channelId) {
+    final condition = {
+      'id': channelId.toString(),
+      'ctx': 'channel',
+      'platform': 'TWITCH'
+    };
+    _send(35, {'type': 'cosmetic.*', 'condition': condition});
+    _send(35, {'type': 'entitlement.*', 'condition': condition});
+  }
+
+  void _startHeartbeatChecker() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (_expectedHeartbeatInterval <= 0) return;
+      if (_lastHeartbeat <= 0) return;
+      final now = DateTime.now().millisecondsSinceEpoch;
+      if (now - _lastHeartbeat > _expectedHeartbeatInterval) {
+        _heartbeatFailedCount += 1;
+      }
+      if (_heartbeatFailedCount >= 3) {
+        _reconnect();
+      }
+    });
+  }
+
+  void _handleMessage(dynamic data) {
+    if (data == null) return;
+
+    final Map<String, dynamic> message;
+    try {
+      message = jsonDecode(data.toString()) as Map<String, dynamic>;
+    } catch (_) {
+      return;
+    }
+
+    final op = message['op'];
+    if (op is! int) return;
+
+    switch (op) {
+      case 1:
+        final d = message['d'];
+        if (d is Map<String, dynamic>) {
+          _expectedHeartbeatInterval = (d['heartbeat_interval'] as int?) ?? 0;
+          _lastHeartbeat = DateTime.now().millisecondsSinceEpoch;
+          _heartbeatFailedCount = 0;
+          _startHeartbeatChecker();
+        }
+        break;
+      case 2:
+        _lastHeartbeat = DateTime.now().millisecondsSinceEpoch;
+        _heartbeatFailedCount = 0;
+        break;
+      case 0:
+        final d = message['d'];
+        if (d is Map<String, dynamic>) {
+          _handleDispatch(d);
+        }
+        break;
+    }
+  }
+
+  void _handleDispatch(Map<String, dynamic> dispatch) {
+    final type = dispatch['type'];
+    final body = dispatch['body'];
+    if (type is! String || body is! Map<String, dynamic>) return;
+
+    if (type == 'cosmetic.create') {
+      _handleCosmeticCreate(body);
+    } else if (type == 'entitlement.create') {
+      _handleEntitlementCreate(body);
+    }
+  }
+
+  void _handleCosmeticCreate(Map<String, dynamic> body) {
+    if (!_isCosmeticPayloadKind(body['kind'])) return;
+
+    final object = body['object'];
+    if (object is! Map<String, dynamic>) return;
+
+    final data = (object['data'] is Map<String, dynamic>)
+        ? object['data'] as Map<String, dynamic>
+        : object;
+    final cosmeticId = data['id']?.toString();
+    if (cosmeticId == null) return;
+
+    _cosmeticsById[cosmeticId] = data;
+
+    final entitlements = _entitlementsByCosmeticId[cosmeticId];
+    if (entitlements == null) return;
+    for (final ent in entitlements) {
+      _emitCombinedCosmetic(
+          cosmeticId: cosmeticId, cosmetic: data, entitlement: ent);
+    }
+  }
+
+  void _handleEntitlementCreate(Map<String, dynamic> body) {
+    if (!_isCosmeticPayloadKind(body['kind'])) return;
+
+    final object = body['object'];
+    if (object is! Map<String, dynamic>) return;
+
+    final user = object['user'];
+    if (user is! Map<String, dynamic>) return;
+
+    final cosmeticId = object['ref_id']?.toString();
+    if (cosmeticId == null) return;
+
+    final entitlement = <String, dynamic>{
+      'id': cosmeticId,
+      'kind': object['kind'],
+      'selected': true,
+      'user': user,
+    };
+
+    final list =
+        _entitlementsByCosmeticId[cosmeticId] ?? <Map<String, dynamic>>[];
+    list.add(entitlement);
+    _entitlementsByCosmeticId[cosmeticId] = list;
+
+    final cosmetic = _cosmeticsById[cosmeticId];
+    if (cosmetic == null) return;
+    _emitCombinedCosmetic(
+        cosmeticId: cosmeticId, cosmetic: cosmetic, entitlement: entitlement);
+  }
+
+  void _emitCombinedCosmetic({
+    required String cosmeticId,
+    required Map<String, dynamic> cosmetic,
+    required Map<String, dynamic> entitlement,
+  }) {
+    final user = entitlement['user'];
+    if (user is! Map<String, dynamic>) return;
+
+    final twitchUserId = _extractTwitchUserId(user);
+    if (twitchUserId == null) return;
+
+    final key = '$twitchUserId:$cosmeticId';
+    if (_emittedUserCosmeticKeys.contains(key)) return;
+    _emittedUserCosmeticKeys.add(key);
+
+    final kind = _extractCosmeticKind(cosmetic, entitlement);
+    if (kind == null) return;
+
+    if (kind == 'BADGE') {
+      final badge =
+          _badgeFromCosmetic(cosmeticId: cosmeticId, cosmetic: cosmetic);
+      if (badge == null) return;
+
+      final nextBadges =
+          Map<int, List<twitch.Badge>>.from(state.badgesByTwitchUserId);
+      final existing = nextBadges[twitchUserId] ?? <twitch.Badge>[];
+      nextBadges[twitchUserId] = [...existing, badge];
+
+      emit(
+        SevenTvCosmeticsState(
+          badgesByTwitchUserId: nextBadges,
+          paintsByTwitchUserId: state.paintsByTwitchUserId,
+          subscribedChannelIds: state.subscribedChannelIds,
+        ),
+      );
+      return;
+    }
+
+    if (kind == 'PAINT') {
+      final paint = _paintFromCosmetic(cosmetic: cosmetic);
+      if (paint == null) return;
+
+      emit(
+        SevenTvCosmeticsState(
+          badgesByTwitchUserId: state.badgesByTwitchUserId,
+          paintsByTwitchUserId: {
+            ...state.paintsByTwitchUserId,
+            twitchUserId: paint
+          },
+          subscribedChannelIds: state.subscribedChannelIds,
+        ),
+      );
+    }
+  }
+
+  bool _isCosmeticPayloadKind(dynamic kind) {
+    if (kind == 10) return true;
+    if (kind is String)
+      return kind.toUpperCase() == '10' || kind.toUpperCase() == 'COSMETIC';
+    return kind?.toString() == '10';
+  }
+
+  int? _extractTwitchUserId(Map<String, dynamic> user) {
+    final connections = user['connections'];
+    if (connections is List) {
+      for (final conn in connections) {
+        if (conn is! Map) continue;
+        if (conn['platform']?.toString().toUpperCase() != 'TWITCH') continue;
+        final id = int.tryParse(conn['id']?.toString() ?? '');
+        if (id != null) return id;
+      }
+    }
+
+    final platform = user['platform']?.toString().toUpperCase();
+    final id = int.tryParse(user['id']?.toString() ?? '');
+    if (platform == 'TWITCH' && id != null) return id;
+
+    for (final key in const ['platform_id', 'twitch_id']) {
+      final parsed = int.tryParse(user[key]?.toString() ?? '');
+      if (parsed != null) return parsed;
+    }
+
+    return null;
+  }
+
+  String? _extractCosmeticKind(
+      Map<String, dynamic> cosmetic, Map<String, dynamic> entitlement) {
+    final kind = cosmetic['kind'] ?? entitlement['kind'];
+    return kind?.toString().toUpperCase();
+  }
+
+  twitch.Badge? _badgeFromCosmetic({
+    required String cosmeticId,
+    required Map<String, dynamic> cosmetic,
+  }) {
+    final host = cosmetic['host'];
+    if (host is! Map<String, dynamic>) return null;
+
+    final mipmap = _selectBestImages(host);
+    if (mipmap.isEmpty) return null;
+
+    final title = cosmetic['name']?.toString() ?? '7TV Badge';
+
+    return twitch.Badge(
+      tag: '7tv/$cosmeticId',
+      name: '7tv',
+      id: cosmeticId,
+      title: title,
+      description: null,
+      mipmap: mipmap,
+      cache: true,
+    );
+  }
+
+  SevenTvPaint? _paintFromCosmetic({required Map<String, dynamic> cosmetic}) {
+    final function = cosmetic['function']?.toString();
+    if (function == null) return null;
+
+    final repeat = cosmetic['repeat'] == true;
+    final angle = (cosmetic['angle'] is num)
+        ? (cosmetic['angle'] as num).toDouble()
+        : null;
+    final shape = cosmetic['shape']?.toString();
+    final imageUrl =
+        (cosmetic['image_url'] ?? cosmetic['imageUrl'] ?? cosmetic['image'])
+            ?.toString();
+    final stops = _parsePaintStops(cosmetic['stops']);
+    final dropShadows =
+        _parseDropShadows(cosmetic['shadows'] ?? cosmetic['drop_shadows']);
+
+    return SevenTvPaint(
+      function: function.toUpperCase(),
+      repeat: repeat,
+      angle: angle,
+      shape: shape,
+      imageUrl: imageUrl,
+      stops: stops,
+      dropShadows: dropShadows,
+    );
+  }
+
+  List<SevenTvPaintStop> _parsePaintStops(dynamic rawStops) {
+    if (rawStops == null) return const [];
+    if (rawStops is! List) return const [];
+
+    final stops = <SevenTvPaintStop>[];
+    for (final stop in rawStops) {
+      if (stop is! Map) continue;
+      final color =
+          _parseSevenTvColor(stop['color']) ?? const Color(0xFFFFFFFF);
+      final at = stop['at'] ?? stop['position'] ?? 0;
+      final position =
+          (at is num) ? at.toDouble() : double.tryParse(at.toString()) ?? 0.0;
+      stops.add(
+          SevenTvPaintStop(color: color, position: position.clamp(0.0, 1.0)));
+    }
+    stops.sort((a, b) => a.position.compareTo(b.position));
+    return stops;
+  }
+
+  List<SevenTvDropShadow> _parseDropShadows(dynamic rawShadows) {
+    if (rawShadows == null) return const [];
+    if (rawShadows is! List) return const [];
+
+    final shadows = <SevenTvDropShadow>[];
+    for (final shadow in rawShadows) {
+      if (shadow is! Map) continue;
+
+      final xOffset =
+          _parseDouble(shadow['x_offset'] ?? shadow['xOffset']) ?? 0.0;
+      final yOffset =
+          _parseDouble(shadow['y_offset'] ?? shadow['yOffset']) ?? 0.0;
+      final radius = _parseDouble(shadow['radius']) ?? 0.0;
+      final color =
+          _parseSevenTvColor(shadow['color']) ?? const Color(0xFF000000);
+
+      if (radius > 0) {
+        shadows.add(SevenTvDropShadow(
+          xOffset: xOffset,
+          yOffset: yOffset,
+          radius: radius,
+          color: color,
+        ));
+      }
+    }
+    return shadows;
+  }
+
+  double? _parseDouble(dynamic value) {
+    if (value == null) return null;
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    return null;
+  }
+
+  Color? _parseSevenTvColor(dynamic raw) {
+    if (raw is int) {
+      final r = (raw >> 24) & 0xFF;
+      final g = (raw >> 16) & 0xFF;
+      final b = (raw >> 8) & 0xFF;
+      final a = raw & 0xFF;
+      return Color.fromARGB(a, r, g, b);
+    }
+
+    final s = raw?.toString();
+    if (s == null || !s.startsWith('#')) return null;
+
+    final hex = s.substring(1);
+    if (hex.length == 6) return Color(int.parse('FF$hex', radix: 16));
+    if (hex.length == 8) {
+      final rrggbb = hex.substring(0, 6);
+      final aa = hex.substring(6, 8);
+      return Color(int.parse('$aa$rrggbb', radix: 16));
+    }
+
+    return null;
+  }
+
+  List<String?> _selectBestImages(Map<String, dynamic> host) {
+    final files = host['files'];
+    final rawUrl = host['url']?.toString();
+    if (files is! List || rawUrl == null) return const [];
+
+    final base = rawUrl.startsWith('http') ? rawUrl : 'https:$rawUrl';
+
+    String? findByName(String name) {
+      for (final f in files) {
+        if (f is! Map) continue;
+        if (f['name']?.toString() == name) return '$base/$name';
+      }
+      return null;
+    }
+
+    final order = const ['1x.webp', '2x.webp', '3x.webp', '4x.webp'];
+    final urls = <String?>[];
+
+    for (final name in order) {
+      final url = findByName(name);
+      if (url != null) urls.add(url);
+    }
+
+    if (urls.isNotEmpty) return urls;
+
+    for (final f in files) {
+      if (f is! Map) continue;
+      final name = f['name']?.toString();
+      final format = f['format']?.toString().toUpperCase();
+      if (name == null) continue;
+      if (format == 'WEBP' || name.toLowerCase().endsWith('.webp')) {
+        urls.add('$base/$name');
+      }
+    }
+
+    return urls;
+  }
+}

--- a/lib/Pages/Home.dart
+++ b/lib/Pages/Home.dart
@@ -22,7 +22,7 @@ import '/Mentions/MentionsCubit.dart';
 import '/Settings/Settings.dart';
 import '/Settings/SettingsEvent.dart';
 import '/Settings/SettingsState.dart';
-import '/Cosmetics/SevenTvCosmeticsCubit.dart';
+import '../Cosmetics/SevenTvCosmetics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -752,14 +752,14 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
       Future.delayed(const Duration(milliseconds: 100), () {
         if (!mounted) return;
         if (channel.id != null) {
-          BlocProvider.of<SevenTvCosmeticsCubit>(context)
+          BlocProvider.of<SevenTvCosmetics>(context)
               .subscribeToChannelId(channel.id!);
         }
       });
       return;
     }
 
-    BlocProvider.of<SevenTvCosmeticsCubit>(context)
+    BlocProvider.of<SevenTvCosmetics>(context)
         .subscribeToChannelId(channel.id!);
   }
 

--- a/lib/Pages/Home.dart
+++ b/lib/Pages/Home.dart
@@ -22,6 +22,7 @@ import '/Mentions/MentionsCubit.dart';
 import '/Settings/Settings.dart';
 import '/Settings/SettingsEvent.dart';
 import '/Settings/SettingsState.dart';
+import '/Cosmetics/SevenTvCosmeticsCubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -99,7 +100,8 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
       // Should observe events instead, serves as a quick fix.
       (t) {
         try {
-          var settings = BlocProvider.of<Settings>(context).state as SettingsLoaded;
+          var settings =
+              BlocProvider.of<Settings>(context).state as SettingsLoaded;
           client.useRecentMessages = settings.historyUseRecentMessages;
         } catch (e) {}
         loadChannelHistory();
@@ -120,30 +122,39 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
           var jsonResponse = jsonDecode(utf8.decode(response.bodyBytes));
           print(jsonResponse);
 
-          if (jsonResponse['expires_in'] != null && Duration(seconds: (jsonResponse['expires_in'] ?? -1)) <= Duration(days: 7)) {
+          if (jsonResponse['expires_in'] != null &&
+              Duration(seconds: (jsonResponse['expires_in'] ?? -1)) <=
+                  Duration(days: 7)) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: Text('Your login will expire soon! Please login again to refresh it.'),
+              content: Text(
+                  'Your login will expire soon! Please login again to refresh it.'),
               behavior: SnackBarBehavior.floating,
               action: SnackBarAction(
                 label: 'Re-login',
                 onPressed: () {
                   Navigator.of(context).push(
-                    MaterialPageRoute(builder: (BuildContext context) => OAuthPage(client: client)),
+                    MaterialPageRoute(
+                        builder: (BuildContext context) =>
+                            OAuthPage(client: client)),
                   );
                 },
               ),
             ));
           }
 
-          if (jsonResponse['expires_in'] == null || (jsonResponse['expires_in'] ?? -1) < 0) {
+          if (jsonResponse['expires_in'] == null ||
+              (jsonResponse['expires_in'] ?? -1) < 0) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-              content: Text('Your login has expired! Please login again to refresh it.'),
+              content: Text(
+                  'Your login has expired! Please login again to refresh it.'),
               behavior: SnackBarBehavior.floating,
               action: SnackBarAction(
                 label: 'Re-login',
                 onPressed: () {
                   Navigator.of(context).push(
-                    MaterialPageRoute(builder: (BuildContext context) => OAuthPage(client: client)),
+                    MaterialPageRoute(
+                        builder: (BuildContext context) =>
+                            OAuthPage(client: client)),
                   );
                 },
               ),
@@ -163,17 +174,24 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
       ),
     );
 
-    http.get(Uri.parse('https://raw.githubusercontent.com/chatsen/resources/master/assets/version.json')).then((response) async {
+    http
+        .get(Uri.parse(
+            'https://raw.githubusercontent.com/chatsen/resources/master/assets/version.json'))
+        .then((response) async {
       final responseJson = json.decode(utf8.decode(response.bodyBytes));
       print(responseJson);
 
       final packageInfo = await PackageInfo.fromPlatform();
-      final currentReleaseVersion = Version.parse('${packageInfo.version}+${packageInfo.buildNumber}');
+      final currentReleaseVersion =
+          Version.parse('${packageInfo.version}+${packageInfo.buildNumber}');
 
-      final latestStoreVersionString = Platform.isIOS ? responseJson['ios'] : responseJson['android'];
+      final latestStoreVersionString =
+          Platform.isIOS ? responseJson['ios'] : responseJson['android'];
       final latestStoreVersion = Version.parse(latestStoreVersionString);
 
-      if (kPlayStoreRelease && Platform.isIOS && currentReleaseVersion > latestStoreVersion) {
+      if (kPlayStoreRelease &&
+          Platform.isIOS &&
+          currentReleaseVersion > latestStoreVersion) {
         // ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         //   content: Text('You are using a development version!'),
         //   behavior: SnackBarBehavior.floating,
@@ -190,9 +208,11 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
             label: 'Update',
             onPressed: () {
               if (Platform.isIOS) {
-                launchUrl(Uri.parse('https://apps.apple.com/us/app/chatsen/id1574037007'));
+                launchUrl(Uri.parse(
+                    'https://apps.apple.com/us/app/chatsen/id1574037007'));
               } else {
-                launchUrl(Uri.parse('https://play.google.com/store/apps/details?id=com.chatsen.chatsen'));
+                launchUrl(Uri.parse(
+                    'https://play.google.com/store/apps/details?id=com.chatsen.chatsen'));
               }
             },
           ),
@@ -230,7 +250,8 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
       var settingsState = BlocProvider.of<Settings>(context).state;
       if (settingsState is SettingsLoaded && settingsState.setupScreen) {
         await SetupModal.show(context, client);
-        BlocProvider.of<Settings>(context).add(SettingsChange(state: settingsState.copyWith(setupScreen: false)));
+        BlocProvider.of<Settings>(context).add(
+            SettingsChange(state: settingsState.copyWith(setupScreen: false)));
       }
     });
 
@@ -267,10 +288,12 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                     children: [
                       WebView(
                         key: keyTest,
-                        initialUrl: 'https://player.twitch.tv/?channel=${state.channelName}&enableExtensions=true&muted=false&parent=chatsen.app',
+                        initialUrl:
+                            'https://player.twitch.tv/?channel=${state.channelName}&enableExtensions=true&muted=false&parent=chatsen.app',
                         javascriptMode: JavascriptMode.unrestricted,
                         allowsInlineMediaPlayback: true,
-                        onWebViewCreated: (controller) => webViewController = controller,
+                        onWebViewCreated: (controller) =>
+                            webViewController = controller,
                         onPageStarted: (url) {
                           // webViewController!.evaluateJavascript(ffz);
 
@@ -286,7 +309,9 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                           //   document.getElementsByTagName("video")[0].controls = true;
                           // ''');
                         },
-                        userAgent: Platform.isIOS ? 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36' : null,
+                        userAgent: Platform.isIOS
+                            ? 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
+                            : null,
                         // userAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.4) Gecko/20100101 Firefox/4.0',
                       ),
                       // Positioned.fill(
@@ -309,7 +334,9 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
               extendBodyBehindAppBar: true,
               drawer: Builder(
                 builder: (context) {
-                  var currentChannel = client.channels.isNotEmpty ? client.channels[DefaultTabController.of(context)!.index] : null;
+                  var currentChannel = client.channels.isNotEmpty
+                      ? client.channels[DefaultTabController.of(context)!.index]
+                      : null;
                   return HomeDrawer(
                     client: client,
                     channel: currentChannel,
@@ -317,29 +344,41 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                 },
               ),
               endDrawer: HomeEndDrawer(),
-              backgroundColor: (state is StreamOverlayOpened && horizontal && immersive) ? Colors.transparent : null,
+              backgroundColor:
+                  (state is StreamOverlayOpened && horizontal && immersive)
+                      ? Colors.transparent
+                      : null,
               bottomNavigationBar: Builder(
                 builder: (context) {
                   var widget = Material(
-                    color: client.channels.isEmpty ? Theme.of(context).colorScheme.surface.withAlpha(196) : Colors.transparent,
+                    color: client.channels.isEmpty
+                        ? Theme.of(context).colorScheme.surface.withAlpha(196)
+                        : Colors.transparent,
                     child: SafeArea(
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          if (client.channels.isEmpty) Ink(height: 1.0, color: Theme.of(context).dividerColor),
+                          if (client.channels.isEmpty)
+                            Ink(
+                                height: 1.0,
+                                color: Theme.of(context).dividerColor),
                           SizedBox(
                             height: 40.0,
                             child: Row(
                               children: [
                                 Builder(
                                   builder: (context) => InkWell(
-                                    onTap: () async => Scaffold.of(context).openDrawer(),
+                                    onTap: () async =>
+                                        Scaffold.of(context).openDrawer(),
                                     child: Container(
                                       height: 40.0,
                                       width: 40.0,
                                       child: Icon(
                                         Icons.menu,
-                                        color: Theme.of(context).colorScheme.onSurface.withAlpha(64 * 3),
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface
+                                            .withAlpha(64 * 3),
                                       ),
                                     ),
                                   ),
@@ -414,7 +453,10 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                                         backgroundColor: Colors.transparent,
                                         builder: (context) => SafeArea(
                                           child: Padding(
-                                            padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+                                            padding: EdgeInsets.only(
+                                                bottom: MediaQuery.of(context)
+                                                    .viewInsets
+                                                    .bottom),
                                             child: ChannelJoinModal(
                                               client: client,
                                               refresh: () => setState(() {}),
@@ -427,21 +469,32 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                                       height: 40.0,
                                       width: 40.0,
                                       child: Icon(
-                                        (Platform.isMacOS || Platform.isIOS) ? CupertinoIcons.plus : Icons.add,
-                                        color: Theme.of(context).colorScheme.onSurface.withAlpha(64 * 3),
+                                        (Platform.isMacOS || Platform.isIOS)
+                                            ? CupertinoIcons.plus
+                                            : Icons.add,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface
+                                            .withAlpha(64 * 3),
                                       ),
                                     ),
                                   ),
                                 ),
                                 InkWell(
-                                  onTap: () async => Scaffold.of(context).openEndDrawer(),
+                                  onTap: () async =>
+                                      Scaffold.of(context).openEndDrawer(),
                                   child: Container(
                                     height: 40.0,
                                     width: 40.0,
                                     child: Icon(
-                                      (Platform.isMacOS || Platform.isIOS) ? CupertinoIcons.bell : Icons.alternate_email,
+                                      (Platform.isMacOS || Platform.isIOS)
+                                          ? CupertinoIcons.bell
+                                          : Icons.alternate_email,
                                       size: 20.0,
-                                      color: Theme.of(context).colorScheme.onSurface.withAlpha(64 * 3),
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurface
+                                          .withAlpha(64 * 3),
                                     ),
                                   ),
                                 ),
@@ -452,7 +505,9 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                       ),
                     ),
                   );
-                  return client.channels.isEmpty ? WidgetBlur(child: widget) : widget;
+                  return client.channels.isEmpty
+                      ? WidgetBlur(child: widget)
+                      : widget;
                 },
               ),
               body: Stack(
@@ -460,10 +515,12 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                   if (client.channels.isEmpty)
                     SingleChildScrollView(
                       child: Container(
-                        constraints: BoxConstraints(minHeight: MediaQuery.of(context).size.height),
+                        constraints: BoxConstraints(
+                            minHeight: MediaQuery.of(context).size.height),
                         child: Center(
                           child: Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                            padding: EdgeInsets.symmetric(
+                                horizontal: 16.0, vertical: 8.0),
                             child: Tutorial(client: client),
                           ),
                         ),
@@ -476,7 +533,9 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                           ChatView(
                             client: client,
                             channel: channel,
-                            shadow: (state is StreamOverlayOpened && horizontal && immersive),
+                            shadow: (state is StreamOverlayOpened &&
+                                horizontal &&
+                                immersive),
                           ),
                       ],
                     ),
@@ -575,12 +634,14 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                                       alignment: Alignment.bottomCenter,
                                       child: SafeArea(
                                         child: Row(
-                                          mainAxisAlignment: MainAxisAlignment.center,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
                                           children: [
                                             IconButton(
                                               icon: Icon(
                                                 Icons.fullscreen_exit,
-                                                color: Colors.white.withAlpha(192),
+                                                color:
+                                                    Colors.white.withAlpha(192),
                                               ),
                                               onPressed: () => setState(() {
                                                 immersive = false;
@@ -588,10 +649,17 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                                             ),
                                             IconButton(
                                               icon: Icon(
-                                                (Platform.isMacOS || Platform.isIOS) ? CupertinoIcons.line_horizontal_3 : Icons.menu,
-                                                color: Colors.white.withAlpha(192),
+                                                (Platform.isMacOS ||
+                                                        Platform.isIOS)
+                                                    ? CupertinoIcons
+                                                        .line_horizontal_3
+                                                    : Icons.menu,
+                                                color:
+                                                    Colors.white.withAlpha(192),
                                               ),
-                                              onPressed: () => Scaffold.of(context).openEndDrawer(),
+                                              onPressed: () =>
+                                                  Scaffold.of(context)
+                                                      .openEndDrawer(),
                                             ),
                                           ],
                                         ),
@@ -608,7 +676,14 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                                 child: Material(
                                   color: Colors.transparent,
                                   child: Padding(
-                                    padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top, bottom: MediaQuery.of(context).padding.bottom, left: MediaQuery.of(context).padding.left),
+                                    padding: EdgeInsets.only(
+                                        top: MediaQuery.of(context).padding.top,
+                                        bottom: MediaQuery.of(context)
+                                            .padding
+                                            .bottom,
+                                        left: MediaQuery.of(context)
+                                            .padding
+                                            .left),
                                     child: Stack(
                                       children: [
                                         videoPlayer!,
@@ -616,12 +691,14 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
                                           alignment: Alignment.bottomCenter,
                                           child: SafeArea(
                                             child: Row(
-                                              mainAxisAlignment: MainAxisAlignment.center,
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.center,
                                               children: [
                                                 IconButton(
                                                   icon: Icon(
                                                     Icons.fullscreen,
-                                                    color: Colors.white.withAlpha(192),
+                                                    color: Colors.white
+                                                        .withAlpha(192),
                                                   ),
                                                   onPressed: () => setState(() {
                                                     immersive = true;
@@ -669,11 +746,26 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
 
   @override
   void onChannelStateChange(twitch.Channel channel, twitch.ChannelState state) {
-    setState(() {});
+    if (state != twitch.ChannelState.Connected) return;
+
+    if (channel.id == null) {
+      Future.delayed(const Duration(milliseconds: 100), () {
+        if (!mounted) return;
+        if (channel.id != null) {
+          BlocProvider.of<SevenTvCosmeticsCubit>(context)
+              .subscribeToChannelId(channel.id!);
+        }
+      });
+      return;
+    }
+
+    BlocProvider.of<SevenTvCosmeticsCubit>(context)
+        .subscribeToChannelId(channel.id!);
   }
 
   @override
-  void onConnectionStateChange(twitch.Connection connection, twitch.ConnectionState state) {
+  void onConnectionStateChange(
+      twitch.Connection connection, twitch.ConnectionState state) {
     setState(() {});
   }
 
@@ -681,15 +773,20 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
   void onMessage(twitch.Channel? channel, twitch.Message message) {
     var splits = message.body!.split(' ').where((split) => split.isNotEmpty);
 
-    message.blocked = BlocProvider.of<BlockedTermsCubit>(context).state.firstWhereOrNull((customTerm) {
-          if (customTerm.regex) return RegExp(customTerm.pattern).hasMatch(message.body!);
+    message.blocked = BlocProvider.of<BlockedTermsCubit>(context)
+            .state
+            .firstWhereOrNull((customTerm) {
+          if (customTerm.regex)
+            return RegExp(customTerm.pattern).hasMatch(message.body!);
           if (customTerm.caseSensitive) {
             return message.body!.contains(customTerm.pattern);
             // return splits.any(
             //   (split) => (split == customTerm.pattern),
             // );
           }
-          return message.body!.toLowerCase().contains(customTerm.pattern.toLowerCase());
+          return message.body!
+              .toLowerCase()
+              .contains(customTerm.pattern.toLowerCase());
           // return splits.any(
           // (split) => (split.toLowerCase() == customTerm.pattern.toLowerCase()),
           // );
@@ -699,24 +796,36 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
     if (message.blocked) return;
 
     // message.mention = true;
-    var contains = BlocProvider.of<CustomMentionsCubit>(context).state.firstWhereOrNull((customMention) {
+    var contains = BlocProvider.of<CustomMentionsCubit>(context)
+        .state
+        .firstWhereOrNull((customMention) {
       try {
-        if (customMention.enableRegex) return RegExp(customMention.pattern).hasMatch(message.body!);
+        if (customMention.enableRegex)
+          return RegExp(customMention.pattern).hasMatch(message.body!);
         // ignore: empty_catches
       } catch (e) {}
       if (customMention.caseSensitive) {
         return splits.any(
-          (split) => (split == customMention.pattern || split == '@${customMention.pattern}' || split == '${customMention.pattern},' || split == '@${customMention.pattern},'),
+          (split) => (split == customMention.pattern ||
+              split == '@${customMention.pattern}' ||
+              split == '${customMention.pattern},' ||
+              split == '@${customMention.pattern},'),
         );
       }
       return splits.any(
-        (split) => (split.toLowerCase() == customMention.pattern.toLowerCase() || split.toLowerCase() == '@${customMention.pattern.toLowerCase()}' || split.toLowerCase() == '${customMention.pattern.toLowerCase()},' || split.toLowerCase() == '@${customMention.pattern.toLowerCase()},'),
+        (split) => (split.toLowerCase() ==
+                customMention.pattern.toLowerCase() ||
+            split.toLowerCase() == '@${customMention.pattern.toLowerCase()}' ||
+            split.toLowerCase() == '${customMention.pattern.toLowerCase()},' ||
+            split.toLowerCase() == '@${customMention.pattern.toLowerCase()},'),
       );
     });
     message.mention = message.mention || contains != null;
 
     if (message.mention) BlocProvider.of<MentionsCubit>(context).add(message);
-    if ((BlocProvider.of<Settings>(context).state as SettingsLoaded).notificationOnMention && message.mention) {
+    if ((BlocProvider.of<Settings>(context).state as SettingsLoaded)
+            .notificationOnMention &&
+        message.mention) {
       NotificationWrapper.of(context)!.sendNotification(
         payload: message.body,
         title: '${message.user!.login} in ${channel!.name}',
@@ -730,7 +839,9 @@ class _HomePageState extends State<HomePage> implements twitch.Listener {
 
   @override
   void onWhisper(twitch.Channel channel, twitch.Message message) {
-    if ((BlocProvider.of<Settings>(context).state as SettingsLoaded).notificationOnWhisper && message.user!.id != channel.receiver!.credentials!.id) {
+    if ((BlocProvider.of<Settings>(context).state as SettingsLoaded)
+            .notificationOnWhisper &&
+        message.user!.id != channel.receiver!.credentials!.id) {
       NotificationWrapper.of(context)!.sendNotification(
         payload: message.body,
         title: message.user!.login,
@@ -752,8 +863,10 @@ class Tutorial extends StatelessWidget {
   Widget build(BuildContext context) => SafeArea(
         child: Column(
           children: [
-            Icon(Icons.not_started, size: 48.0, color: Theme.of(context).colorScheme.primary),
-            Text('Getting started', style: Theme.of(context).textTheme.headline5),
+            Icon(Icons.not_started,
+                size: 48.0, color: Theme.of(context).colorScheme.primary),
+            Text('Getting started',
+                style: Theme.of(context).textTheme.headline5),
             // Text('To get started, you can join a channel by pressing the + button below.', textAlign: TextAlign.center),
             // SizedBox(height: 32.0),
             // Text('Help', style: Theme.of(context).textTheme.headline5),
@@ -762,7 +875,9 @@ class Tutorial extends StatelessWidget {
               children: [
                 Icon(Icons.add),
                 SizedBox(width: 16.0),
-                Expanded(child: Text('The add icon allows you to join channels by typing in their names. You can join multiple channels by separating the names with spaces: "chatsen btmc twitch"')),
+                Expanded(
+                    child: Text(
+                        'The add icon allows you to join channels by typing in their names. You can join multiple channels by separating the names with spaces: "chatsen btmc twitch"')),
               ],
             ),
             SizedBox(height: 16.0),
@@ -770,7 +885,9 @@ class Tutorial extends StatelessWidget {
               children: [
                 Icon(Icons.menu),
                 SizedBox(width: 16.0),
-                Expanded(child: Text('The menu icon will open the primary menu of the application. You can also hold-and-slide from the left edge to the right to open it!')),
+                Expanded(
+                    child: Text(
+                        'The menu icon will open the primary menu of the application. You can also hold-and-slide from the left edge to the right to open it!')),
               ],
             ),
             SizedBox(height: 16.0),
@@ -778,7 +895,9 @@ class Tutorial extends StatelessWidget {
               children: [
                 Icon(Icons.alternate_email),
                 SizedBox(width: 16.0),
-                Expanded(child: Text('The email icon will open the mentions menu of the application. You can also hold-and-slide from the right edge to the left to open it!')),
+                Expanded(
+                    child: Text(
+                        'The email icon will open the mentions menu of the application. You can also hold-and-slide from the right edge to the left to open it!')),
               ],
             ),
             SizedBox(height: 32.0),
@@ -791,7 +910,8 @@ class Tutorial extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   ElevatedButton.icon(
-                    onPressed: () => Navigator.of(context).push(MaterialPageRoute(
+                    onPressed: () =>
+                        Navigator.of(context).push(MaterialPageRoute(
                       builder: (context) => AccountPage(
                         client: client,
                       ),
@@ -799,8 +919,10 @@ class Tutorial extends StatelessWidget {
                     icon: Icon(Icons.account_circle),
                     label: Text('Add an account'),
                     style: ButtonStyle(
-                      shape: MaterialStateProperty.all(RoundedRectangleBorder(borderRadius: BorderRadius.circular(32.0))),
-                      padding: MaterialStateProperty.all(EdgeInsets.symmetric(horizontal: 24.0, vertical: 24.0 / 2.0)),
+                      shape: MaterialStateProperty.all(RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(32.0))),
+                      padding: MaterialStateProperty.all(EdgeInsets.symmetric(
+                          horizontal: 24.0, vertical: 24.0 / 2.0)),
                     ),
                   ),
                   SizedBox(height: 8.0),
@@ -809,13 +931,16 @@ class Tutorial extends StatelessWidget {
                       await client.joinChannels(['#chatsenapp']);
                       var channelsBox = await Hive.openBox('Channels');
                       await channelsBox.clear();
-                      await channelsBox.addAll(client.channels.map((channel) => channel.name));
+                      await channelsBox.addAll(
+                          client.channels.map((channel) => channel.name));
                     },
                     icon: Icon(Icons.chat),
                     label: Text('Join #chatsenapp'),
                     style: ButtonStyle(
-                      shape: MaterialStateProperty.all(RoundedRectangleBorder(borderRadius: BorderRadius.circular(32.0))),
-                      padding: MaterialStateProperty.all(EdgeInsets.symmetric(horizontal: 24.0, vertical: 24.0 / 2.0)),
+                      shape: MaterialStateProperty.all(RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(32.0))),
+                      padding: MaterialStateProperty.all(EdgeInsets.symmetric(
+                          horizontal: 24.0, vertical: 24.0 / 2.0)),
                     ),
                   ),
                   SizedBox(height: 8.0),
@@ -824,8 +949,10 @@ class Tutorial extends StatelessWidget {
                     icon: Icon(Icons.alternate_email),
                     label: Text('Open mentions'),
                     style: ButtonStyle(
-                      shape: MaterialStateProperty.all(RoundedRectangleBorder(borderRadius: BorderRadius.circular(32.0))),
-                      padding: MaterialStateProperty.all(EdgeInsets.symmetric(horizontal: 24.0, vertical: 24.0 / 2.0)),
+                      shape: MaterialStateProperty.all(RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(32.0))),
+                      padding: MaterialStateProperty.all(EdgeInsets.symmetric(
+                          horizontal: 24.0, vertical: 24.0 / 2.0)),
                     ),
                   ),
                 ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'Badges/ChatsenBadges.dart';
 import 'Badges/ChattyBadges.dart';
 import 'Badges/FFZAPBadges.dart';
 import 'Badges/SevenTVBadges.dart';
+import 'Cosmetics/SevenTvCosmeticsCubit.dart';
 import 'Mentions/CustomMentionsCubit.dart';
 import 'Mentions/MentionsCubit.dart';
 import 'Settings/Settings.dart';
@@ -73,6 +74,7 @@ Future<void> appRunner() async {
         BlocProvider(create: (BuildContext context) => ChatterinoBadges()),
         BlocProvider(create: (BuildContext context) => DankChatBadges()),
         BlocProvider(create: (BuildContext context) => SevenTVBadges()),
+        BlocProvider(create: (BuildContext context) => SevenTvCosmeticsCubit()),
         BlocProvider(create: (BuildContext context) => ChatsenBadges()),
         BlocProvider(create: (BuildContext context) => Chatsen2Badges()),
         BlocProvider(create: (BuildContext context) => MentionsCubit()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ import 'Badges/ChatsenBadges.dart';
 import 'Badges/ChattyBadges.dart';
 import 'Badges/FFZAPBadges.dart';
 import 'Badges/SevenTVBadges.dart';
-import 'Cosmetics/SevenTvCosmeticsCubit.dart';
+import 'Cosmetics/SevenTvCosmetics.dart';
 import 'Mentions/CustomMentionsCubit.dart';
 import 'Mentions/MentionsCubit.dart';
 import 'Settings/Settings.dart';
@@ -63,10 +63,16 @@ Future<void> appRunner() async {
   runApp(
     MultiBlocProvider(
       providers: [
-        if (!kPlayStoreRelease) BlocProvider(create: (BuildContext context) => BackgroundDaemonCubit()),
-        BlocProvider(create: (BuildContext context) => CommandsCubit(commandsBox)),
-        BlocProvider(create: (BuildContext context) => CustomMentionsCubit(customMentionsBox)),
-        BlocProvider(create: (BuildContext context) => AccountsCubit(accountsBox)),
+        if (!kPlayStoreRelease)
+          BlocProvider(
+              create: (BuildContext context) => BackgroundDaemonCubit()),
+        BlocProvider(
+            create: (BuildContext context) => CommandsCubit(commandsBox)),
+        BlocProvider(
+            create: (BuildContext context) =>
+                CustomMentionsCubit(customMentionsBox)),
+        BlocProvider(
+            create: (BuildContext context) => AccountsCubit(accountsBox)),
         BlocProvider(create: (BuildContext context) => FFZAPBadges()),
         BlocProvider(create: (BuildContext context) => FFZBadges()),
         BlocProvider(create: (BuildContext context) => BTTVBadges()),
@@ -74,16 +80,22 @@ Future<void> appRunner() async {
         BlocProvider(create: (BuildContext context) => ChatterinoBadges()),
         BlocProvider(create: (BuildContext context) => DankChatBadges()),
         BlocProvider(create: (BuildContext context) => SevenTVBadges()),
-        BlocProvider(create: (BuildContext context) => SevenTvCosmeticsCubit()),
+        BlocProvider(create: (BuildContext context) => SevenTvCosmetics()),
         BlocProvider(create: (BuildContext context) => ChatsenBadges()),
         BlocProvider(create: (BuildContext context) => Chatsen2Badges()),
         BlocProvider(create: (BuildContext context) => MentionsCubit()),
-        BlocProvider(create: (BuildContext context) => ThemeBloc(themeBox, mode: ThemeMode.dark, colorScheme: 'cyan')),
+        BlocProvider(
+            create: (BuildContext context) =>
+                ThemeBloc(themeBox, mode: ThemeMode.dark, colorScheme: 'cyan')),
         // BlocProvider(create: (BuildContext context) => DownloadManager()),
         BlocProvider(create: (BuildContext context) => StreamOverlayBloc()),
         BlocProvider(create: (BuildContext context) => Settings(settingsBox)),
-        BlocProvider(create: (BuildContext context) => BlockedUsersCubit(blockedUsersBox)),
-        BlocProvider(create: (BuildContext context) => BlockedTermsCubit(blockedTermsBox)),
+        BlocProvider(
+            create: (BuildContext context) =>
+                BlockedUsersCubit(blockedUsersBox)),
+        BlocProvider(
+            create: (BuildContext context) =>
+                BlockedTermsCubit(blockedTermsBox)),
       ],
       child: App(),
     ),
@@ -101,7 +113,6 @@ void main() async {
     //   appRunner: appRunner,
     // );
     await appRunner();
-
   } else {
     await appRunner();
   }


### PR DESCRIPTION
Hey,

i added support for 7TV Cosmetic Badges (colored/animated name plates)

This was requested earlier in #221 

I implemented this in my fork. Maybe it is something you want to take a look at and consider for the main repo.

- 7TV username paints including gradients and image based paints
- 7TV badges via the official 7TV events websocket
- Channel based subscriptions, no per user connections
- Single websocket connection, no polling

I know PRs are not allowed but I think it would be a nice feature.

I also tested it on a real device (iPad pro) and simulator

<img width="564" height="1077" alt="Image" src="https://github.com/user-attachments/assets/875e3ff9-749d-4f79-8bc5-a26542b0dbc8" />